### PR TITLE
[feature] Add Window dashboard

### DIFF
--- a/frontend/chessapp/package-lock.json
+++ b/frontend/chessapp/package-lock.json
@@ -16453,23 +16453,6 @@
         }
       }
     },
-    "node_modules/tailwindcss/node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/tapable": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",

--- a/frontend/chessapp/src/App.jsx
+++ b/frontend/chessapp/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import './App.css';
 import PredForm from './PredForm';
 
@@ -11,6 +11,24 @@ function App() {
   const [result, setResult] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const [co2Level] = useState(1200);
+  const [co2Threshold] = useState(1000);
+  const [windowState, setWindowState] = useState('Closed');
+  const [windowNotification, setWindowNotification] = useState('');
+  const [lastOpeningAngle, setLastOpeningAngle] = useState(0);
+
+  useEffect(() => {
+  if (co2Level > co2Threshold) {
+    setWindowNotification('Window is going to open...');
+
+    setTimeout(() => {
+      setWindowState('Open');
+      setLastOpeningAngle(45);
+      setWindowNotification('Window is open');
+    }, 5000);
+  }
+}, [co2Level, co2Threshold]);
+
   const handleSubmit = async (e) => {
     e.preventDefault();
     setLoading(true);
@@ -70,7 +88,34 @@ handleSubmit={handleSubmit}
             <p>Temperature: {result.temperature?.value ?? 'N/A'} °C</p>
           </div>
         </div>
-      )}
+      )} 
+
+      <div className="card mt-4 mx-auto text-center" style={{ maxWidth: '480px' }}>
+  <div className="card-body">
+    <h4>Window</h4>
+
+    <p>
+      <strong>Window State:</strong> {windowState}
+    </p>
+
+    <p>
+      <strong>CO2 Level:</strong> {co2Level} ppm
+    </p>
+
+    <p>
+      <strong>Threshold:</strong> {co2Threshold} ppm
+    </p>
+
+    <p>
+      <strong>Last Opening Angle:</strong> {lastOpeningAngle}°
+    </p>
+
+    <p>
+      <strong>Notification:</strong> {windowNotification}
+    </p>
+  </div>
+</div>
+
     </div>
   );
 }


### PR DESCRIPTION
What changed:
- Added a frontend window dashboard using mock CO2 data.
- Displays window state, CO2 level, threshold, last opening angle, and notification.
- Simulates opening the window after CO2 stays above threshold for 5 seconds.

How tested:
- Ran the React app locally.
- Verified the window state changes from Closed to Open after 5 seconds.

Notes:
- This is frontend-only mock data.
- No IoT, ML, backend, or service code was changed.
<img width="411" height="755" alt="Window" src="https://github.com/user-attachments/assets/1fd5670c-160d-41ba-abfa-31ee54c4ef75" />
