### PR TITLE
Implement Lichess OAuth login system

### DIFF
--- a/api-gateway/server.js
+++ b/api-gateway/server.js
@@ -122,6 +122,84 @@ app.get("/iot/temp", (req, res) => {
   });
 });
 
+// POST /auth/lichess/callback
+// Body: { code, code_verifier }
+// Exchanges the Lichess authorization code for an access token,
+// then fetches the authenticated Lichess account.
+app.post("/auth/lichess/callback", async (req, res) => {
+  const { code, code_verifier } = req.body;
+
+  const clientId = process.env.LICHESS_CLIENT_ID || "chess-assistance";
+  const redirectUri =
+    process.env.LICHESS_REDIRECT_URI || "http://localhost:3000/callback";
+
+  if (!code || !code_verifier) {
+    return res.status(400).json({
+      error: "Missing code or code_verifier",
+    });
+  }
+
+  try {
+    const tokenResponse = await fetch("https://lichess.org/api/token", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        redirect_uri: redirectUri,
+        client_id: clientId,
+        code_verifier,
+      }),
+    });
+
+    if (!tokenResponse.ok) {
+      const errorText = await tokenResponse.text();
+      console.error("Lichess token exchange failed:", errorText);
+
+      return res.status(500).json({
+        error: "Lichess token exchange failed",
+        details: errorText,
+      });
+    }
+
+    const tokenData = await tokenResponse.json();
+    const accessToken = tokenData.access_token;
+
+    const accountResponse = await fetch("https://lichess.org/api/account", {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    if (!accountResponse.ok) {
+      const errorText = await accountResponse.text();
+      console.error("Lichess account fetch failed:", errorText);
+
+      return res.status(500).json({
+        error: "Lichess account fetch failed",
+        details: errorText,
+      });
+    }
+
+    const accountData = await accountResponse.json();
+
+    res.json({
+      player_username: accountData.username,
+      player_id: accountData.id,
+      lichess_token: accessToken,
+    });
+  } catch (err) {
+    console.error("Lichess OAuth callback error:", err);
+
+    res.status(500).json({
+      error: "Lichess OAuth callback failed",
+      details: err.message,
+    });
+  }
+});
+
 // ===================== START =====================
 app.listen(3001, () => {
   console.log("API Gateway running on port 3001");

--- a/frontend/chessapp/src/App.jsx
+++ b/frontend/chessapp/src/App.jsx
@@ -3,6 +3,7 @@ import Home from "./pages/Home";
 import ChessTrack from "./pages/ChessTrack";
 import IotDashboard from "./pages/IotDashboard";
 import Login from "./pages/Login.jsx";
+import Callback from "./pages/Callback";
 
 function App() {
   return (
@@ -12,6 +13,7 @@ function App() {
         <Route path="/chesstrack" element={<ChessTrack />} />
         <Route path="/iot-dashboard" element={<IotDashboard />} />
         <Route path="/login" element={<Login />} />
+        <Route path="/callback" element={<Callback />} />
       </Routes>
     </Router>
   );

--- a/frontend/chessapp/src/App.jsx
+++ b/frontend/chessapp/src/App.jsx
@@ -2,6 +2,7 @@ import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Home from "./pages/Home";
 import ChessTrack from "./pages/ChessTrack";
 import IotDashboard from "./pages/IotDashboard";
+import Login from "./pages/Login.jsx";
 
 function App() {
   return (
@@ -10,6 +11,7 @@ function App() {
         <Route path="/" element={<Home />} />
         <Route path="/chesstrack" element={<ChessTrack />} />
         <Route path="/iot-dashboard" element={<IotDashboard />} />
+        <Route path="/login" element={<Login />} />
       </Routes>
     </Router>
   );

--- a/frontend/chessapp/src/pages/Callback.jsx
+++ b/frontend/chessapp/src/pages/Callback.jsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from 'react'
+import './Login.css'
+
+function Callback() {
+  const [status, setStatus] = useState('Reading Lichess callback...')
+  const [codeFound, setCodeFound] = useState(false)
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const code = params.get('code')
+    const error = params.get('error')
+
+    if (error) {
+      setStatus(`Lichess login failed: ${error}`)
+      return
+    }
+
+    if (!code) {
+      setStatus('No authorization code was found in the callback URL.')
+      return
+    }
+
+    setCodeFound(true)
+    setStatus('Authorization code received from Lichess.')
+  }, [])
+
+  return (
+    <main className="login-page">
+      <div className="login-card">
+        <p className="login-eyebrow">ChessTrack™</p>
+
+        <h1>Lichess Callback</h1>
+
+        <p className="login-text">{status}</p>
+
+        {codeFound && (
+          <p className="login-text">
+            Next step: exchange this code through the API Gateway.
+          </p>
+        )}
+      </div>
+    </main>
+  )
+}
+
+export default Callback

--- a/frontend/chessapp/src/pages/Callback.jsx
+++ b/frontend/chessapp/src/pages/Callback.jsx
@@ -1,27 +1,76 @@
 import React, { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
 import './Login.css'
 
+const API_BASE = 'http://localhost:3001'
+
 function Callback() {
-  const [status, setStatus] = useState('Reading Lichess callback...')
-  const [codeFound, setCodeFound] = useState(false)
+  const [status, setStatus] = useState('Completing Lichess login...')
+  const [username, setUsername] = useState(null)
 
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search)
-    const code = params.get('code')
-    const error = params.get('error')
+    const completeLogin = async () => {
+      const params = new URLSearchParams(window.location.search)
 
-    if (error) {
-      setStatus(`Lichess login failed: ${error}`)
-      return
+      const code = params.get('code')
+      const error = params.get('error')
+
+      if (error) {
+        setStatus(`Lichess login failed: ${error}`)
+        return
+      }
+
+      if (!code) {
+        setStatus('No authorization code found.')
+        return
+      }
+
+      const codeVerifier = sessionStorage.getItem(
+        'lichess_code_verifier'
+      )
+
+      if (!codeVerifier) {
+        setStatus('Missing PKCE code verifier.')
+        return
+      }
+
+      try {
+        const response = await fetch(
+          `${API_BASE}/auth/lichess/callback`,
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              code,
+              code_verifier: codeVerifier,
+            }),
+          }
+        )
+
+        const data = await response.json()
+
+        if (!response.ok) {
+          throw new Error(
+            data.error || 'Lichess login failed'
+          )
+        }
+
+        localStorage.setItem(
+          'lichess_user',
+          JSON.stringify(data)
+        )
+
+        setUsername(data.player_username)
+        setStatus('Successfully logged into Lichess.')
+      } catch (err) {
+        console.error(err)
+        setStatus(err.message)
+      }
     }
 
-    if (!code) {
-      setStatus('No authorization code was found in the callback URL.')
-      return
-    }
-
-    setCodeFound(true)
-    setStatus('Authorization code received from Lichess.')
+    completeLogin()
   }, [])
 
   return (
@@ -29,15 +78,20 @@ function Callback() {
       <div className="login-card">
         <p className="login-eyebrow">ChessTrack™</p>
 
-        <h1>Lichess Callback</h1>
+        <h1>Lichess Login</h1>
 
         <p className="login-text">{status}</p>
 
-        {codeFound && (
+        {username && (
           <p className="login-text">
-            Next step: exchange this code through the API Gateway.
+            Logged in as: <strong>{username}</strong>
           </p>
         )}
+        <Link to="/">
+         <button className="login-button">
+           Go back home
+         </button>
+        </Link>
       </div>
     </main>
   )

--- a/frontend/chessapp/src/pages/Home.jsx
+++ b/frontend/chessapp/src/pages/Home.jsx
@@ -85,7 +85,9 @@ const [menuOpen, setMenuOpen] = useState(false);
 
   {menuOpen && (
     <div className="profile-dropdown">
-      <button>👤 My Profile</button>
+      <Link to="/login">
+       <button>👤 Login</button>
+      </Link>
       <button>📈 View Sessions</button>
       <button>♟️ Elo Boosting</button>
       <button>⚙️ Settings</button>

--- a/frontend/chessapp/src/pages/Home.jsx
+++ b/frontend/chessapp/src/pages/Home.jsx
@@ -1,5 +1,5 @@
 
-import { useState/*, useRef, useEffect*/ } from "react";
+import { useEffect, useState } from "react";
 // import { Crown, User, History, Settings, TrendingUp } from "lucide-react";
 import { Link } from 'react-router-dom'
 import heroImg from '../assets/chess-bg.png'
@@ -60,6 +60,22 @@ function Home() {
   //     setPlayerLoading(false)
   //   }
   // }
+
+const [lichessUser, setLichessUser] = useState(null)
+
+useEffect(() => {
+  const savedUser = localStorage.getItem('lichess_user')
+
+  if (savedUser) {
+    setLichessUser(JSON.parse(savedUser))
+  }
+}, [])
+
+const handleLogout = () => {
+  localStorage.removeItem('lichess_user')
+  setLichessUser(null)
+}
+
 const [menuOpen, setMenuOpen] = useState(false);
   return (
     <main className="app" style={{ backgroundImage: `url(${heroImg})` }}>
@@ -85,15 +101,28 @@ const [menuOpen, setMenuOpen] = useState(false);
 
   {menuOpen && (
     <div className="profile-dropdown">
-      <Link to="/login">
-       <button>👤 Login</button>
-      </Link>
+      {lichessUser ? (
+        <>
+          <button>
+            👤 {lichessUser.player_username}
+          </button>
+        </>
+      ) : (
+        <Link to="/login">
+          <button>👤 Login</button>
+        </Link>
+      )}
       <button>📈 View Sessions</button>
       <button>♟️ Elo Boosting</button>
       <button>⚙️ Settings</button>
        <Link to="/iot-dashboard">
-    <button>🌐 IoT Dashboard</button>
-  </Link>
+         <button>🌐 IoT Dashboard</button>
+       </Link>
+       {lichessUser && (
+        <button onClick={handleLogout}>
+         🚪 Logout
+        </button>
+       )}
     </div>
   )}
 </div>

--- a/frontend/chessapp/src/pages/Login.css
+++ b/frontend/chessapp/src/pages/Login.css
@@ -1,0 +1,50 @@
+.login-page {
+  min-height: 100vh;
+  background: #010101;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px;
+}
+
+.login-card {
+  width: 100%;
+  max-width: 520px;
+  padding: 42px;
+  border-radius: 24px;
+  background: rgba(0, 0, 0, 0.72);
+  border: 1px solid rgba(216, 170, 85, 0.28);
+  box-shadow: 0 20px 80px rgba(0, 0, 0, 0.55);
+}
+
+.login-eyebrow {
+  color: #d8aa55;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-size: 14px;
+  font-weight: 800;
+  margin: 0 0 16px;
+}
+
+.login-card h1 {
+  margin: 0 0 16px;
+  font-size: 42px;
+}
+
+.login-text {
+  color: #d6d6d6;
+  line-height: 1.6;
+  margin-bottom: 28px;
+}
+
+.login-button {
+  padding: 14px 24px;
+  border-radius: 999px;
+  border: 1px solid rgba(216, 170, 85, 0.6);
+  background: linear-gradient(135deg, #d8aa55, #8f6425);
+  color: #111;
+  font-size: 16px;
+  font-weight: 800;
+  cursor: pointer;
+}

--- a/frontend/chessapp/src/pages/Login.jsx
+++ b/frontend/chessapp/src/pages/Login.jsx
@@ -1,9 +1,47 @@
 import React from 'react'
 import './Login.css'
 
+const CLIENT_ID = 'chess-assistance'
+const REDIRECT_URI = 'http://localhost:3000/callback'
+
+function generateCodeVerifier() {
+  const array = new Uint8Array(64)
+  window.crypto.getRandomValues(array)
+
+  return btoa(String.fromCharCode(...array))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '')
+}
+
+async function generateCodeChallenge(codeVerifier) {
+  const encoder = new TextEncoder()
+  const data = encoder.encode(codeVerifier)
+  const digest = await window.crypto.subtle.digest('SHA-256', data)
+
+  return btoa(String.fromCharCode(...new Uint8Array(digest)))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '')
+}
+
 function Login() {
-  const handleLichessLogin = () => {
-    alert('Lichess OAuth coming next step')
+  const handleLichessLogin = async () => {
+    const codeVerifier = generateCodeVerifier()
+    const codeChallenge = await generateCodeChallenge(codeVerifier)
+
+    sessionStorage.setItem('lichess_code_verifier', codeVerifier)
+
+    const params = new URLSearchParams({
+      response_type: 'code',
+      client_id: CLIENT_ID,
+      redirect_uri: REDIRECT_URI,
+      scope: '',
+      code_challenge: codeChallenge,
+      code_challenge_method: 'S256',
+    })
+
+    window.location.href = `https://lichess.org/oauth?${params.toString()}`
   }
 
   return (

--- a/frontend/chessapp/src/pages/Login.jsx
+++ b/frontend/chessapp/src/pages/Login.jsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import './Login.css'
+
+function Login() {
+  const handleLichessLogin = () => {
+    alert('Lichess OAuth coming next step')
+  }
+
+  return (
+    <main className="login-page">
+      <div className="login-card">
+        <p className="login-eyebrow">ChessTrack™</p>
+
+        <h1>Login with Lichess</h1>
+
+        <p className="login-text">
+          Connect your Lichess account to track your chess activity and
+          performance.
+        </p>
+
+        <button
+          className="login-button"
+          onClick={handleLichessLogin}
+        >
+          Login with Lichess
+        </button>
+      </div>
+    </main>
+  )
+}
+
+export default Login


### PR DESCRIPTION

Implemented functional Lichess OAuth login flow for ChessTrack.

## Changes
- Added dedicated Login page
- Added OAuth callback page
- Implemented PKCE authentication flow
- Added API Gateway endpoint for token exchange
- Fetches authenticated Lichess account username
- Added login persistence using localStorage
- Added logout functionality
- Updated profile dropdown to show logged-in username

## Notes
- Styling intentionally kept minimal for now
- CRA environment currently uses localhost:3000
- API Gateway runs on localhost:3001
- Future Vite migration will require redirect URI/env updates
<img width="835" height="508" alt="image" src="https://github.com/user-attachments/assets/de1939f4-51b8-421f-ae06-1379f31954ce" />
<img width="859" height="762" alt="image" src="https://github.com/user-attachments/assets/91243d77-632a-4ff4-acfd-d70f6d230666" />
<img width="776" height="502" alt="image" src="https://github.com/user-attachments/assets/ae845e74-0021-4dde-90dc-e020cc05ab80" />
<img width="423" height="454" alt="image" src="https://github.com/user-attachments/assets/e88f80a9-578c-41e3-b346-7ec2062f9442" />
