### PR TITLE
fix: message format from the C client changed to match grpc-server

### DIFF
--- a/internet_of_things/sensor_client_c/src/message_builder.c
+++ b/internet_of_things/sensor_client_c/src/message_builder.c
@@ -18,10 +18,10 @@ void create_temperature_message(char *message)
         sprintf(
             message,
             "{"
-                "\"arduinoId\":1,"
-                "\"value\":%.2f,"
-                "\"type\":\"temp\","
-                "\"timestamp\":%ld"
+                "\"ArduinoId\":1,"
+                "\"Value\":%.2f,"
+                "\"Type\":\"temp\","
+                "\"Timestamp\":%ld"
             "}",
             temperature,
             timestamp
@@ -32,10 +32,10 @@ void create_temperature_message(char *message)
         sprintf(
             message,
             "{"
-                "\"arduinoId\":1,"
-                "\"type\":\"temp\","
-                "\"timestamp\":%ld,"
-                "\"value\": null"
+                "\"ArduinoId\":1,"
+                "\"Type\":\"temp\","
+                "\"Timestamp\":%ld,"
+                "\"Value\": 0.00"
             "}",
             timestamp
         );
@@ -52,10 +52,10 @@ void create_light_message(char *message)
         sprintf(
             message,
             "{"
-                "\"arduinoId\":1,"
-                "\"value\":%d,"
-                "\"type\":\"light\","
-                "\"timestamp\":%ld"
+                "\"ArduinoId\":1,"
+                "\"Value\":%d,"
+                "\"Type\":\"light\","
+                "\"Timestamp\":%ld"
             "}",
             light,
             timestamp
@@ -66,10 +66,10 @@ void create_light_message(char *message)
         sprintf(
             message,
             "{"
-                "\"arduinoId\":1,"
-                "\"type\":\"light\","
-                "\"timestamp\":%ld,"
-                "\"value\": null"
+                "\"ArduinoId\":1,"
+                "\"Type\":\"light\","
+                "\"Timestamp\":%ld,"
+                "\"Value\": 0.00"
             "}",
             timestamp
         );

--- a/internet_of_things/sensor_client_c/src/message_builder.c
+++ b/internet_of_things/sensor_client_c/src/message_builder.c
@@ -18,10 +18,10 @@ void create_temperature_message(char *message)
         sprintf(
             message,
             "{"
-                "\"ArduinoId\":1,"
-                "\"Value\":%.2f,"
-                "\"Type\":\"temp\","
-                "\"Timestamp\":%ld"
+                "\"arduinoId\":1,"
+                "\"value\":%.2f,"
+                "\"type\":\"temp\","
+                "\"timestamp\":%ld"
             "}",
             temperature,
             timestamp
@@ -32,10 +32,10 @@ void create_temperature_message(char *message)
         sprintf(
             message,
             "{"
-                "\"ArduinoId\":1,"
-                "\"Type\":\"temp\","
-                "\"Timestamp\":%ld,"
-                "\"Value\": 0.00"
+                "\"arduinoId\":1,"
+                "\"type\":\"temp\","
+                "\"timestamp\":%ld,"
+                "\"value\": 0.00"
             "}",
             timestamp
         );
@@ -52,10 +52,10 @@ void create_light_message(char *message)
         sprintf(
             message,
             "{"
-                "\"ArduinoId\":1,"
-                "\"Value\":%d,"
-                "\"Type\":\"light\","
-                "\"Timestamp\":%ld"
+                "\"arduinoId\":1,"
+                "\"value\":%d,"
+                "\"type\":\"light\","
+                "\"timestamp\":%ld"
             "}",
             light,
             timestamp
@@ -66,10 +66,10 @@ void create_light_message(char *message)
         sprintf(
             message,
             "{"
-                "\"ArduinoId\":1,"
-                "\"Type\":\"light\","
-                "\"Timestamp\":%ld,"
-                "\"Value\": 0.00"
+                "\"arduinoId\":1,"
+                "\"type\":\"light\","
+                "\"timestamp\":%ld,"
+                "\"value\": 0.00"
             "}",
             timestamp
         );

--- a/internet_of_things/sensor_client_c/src/sensor_reader.c
+++ b/internet_of_things/sensor_client_c/src/sensor_reader.c
@@ -128,11 +128,6 @@ int read_light(short *light)
         return 1;
     }
 
-    light_pos = strstr(buffer, "LIGHT:");
-    if (light_pos && sscanf(light_pos, "LIGHT:%hd", light) == 1){
-        return 1;
-    }
-    
     return 0;
 #else
     // --- WINDOWS CLOUD MOCK ---

--- a/internet_of_things/sensor_client_c/src/sensor_reader.c
+++ b/internet_of_things/sensor_client_c/src/sensor_reader.c
@@ -128,6 +128,11 @@ int read_light(short *light)
         return 1;
     }
 
+    light_pos = strstr(buffer, "LIGHT:");
+    if (light_pos && sscanf(light_pos, "LIGHT:%hd", light) == 1){
+        return 1;
+    }
+    
     return 0;
 #else
     // --- WINDOWS CLOUD MOCK ---

--- a/services/iot-service/Grpc-Server/Services/MessageService.cs
+++ b/services/iot-service/Grpc-Server/Services/MessageService.cs
@@ -37,7 +37,11 @@ public class MessageService : BackgroundService, IMessageQueue{
             try
             {
                 var body = ea.Body.ToArray();
-                var obj = JsonSerializer.Deserialize<SensorMessage>(body);
+                var options = new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true
+                };
+                var obj = JsonSerializer.Deserialize<SensorMessage>(body, options);
 
                 if (obj != null)
                 {


### PR DESCRIPTION
There was a wrong message format, gRPC was expecting messages with first letters capitalized, but C was sending everything in small letters. Also, the value for error read should have been 0.00 not null because gRPC deserialized it as System.Single.
Now it works like this:
messages are produces to rabbitMQ and right after consumed by the server, so you cannot see them as queue on the UI.