### PR TITLE
hotfix: correct container name for rabbitmq service in docker-compose.prod.yml

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -33,7 +33,7 @@ services:
 
   rabbitmq:
     image: rabbitmq:management
-    container_name: respawn_rabbitmq
+    container_name: chess-rabbitmq
     restart: unless-stopped
     ports: !reset [] # No external ports exposed for security
     environment:


### PR DESCRIPTION
hotfix: correct container name for rabbitmq service in docker-compose.prod.yml